### PR TITLE
s3 이미지 값이 빈 값 ("") 일 때 s3에서 예외가 터져 조회가 불가 했던 부분 수정

### DIFF
--- a/src/main/java/goorm/back/zo6/conference/application/shared/ConferenceMapper.java
+++ b/src/main/java/goorm/back/zo6/conference/application/shared/ConferenceMapper.java
@@ -40,14 +40,14 @@ public class ConferenceMapper {
     }
 
     private String generateConferenceImageUrl(String imageKey) {
-        if (imageKey == null) {
+        if (imageKey == null || imageKey.isBlank()) {
             return null;
         }
         return s3FileService.generatePresignedUrl(imageKey, 60);
     }
 
     private String generateSpeakerImageUrl(String speakerImageKey) {
-        if (speakerImageKey == null) {
+        if (speakerImageKey == null || speakerImageKey.isBlank()) {
             return null;
         }
         return s3FileService.generatePresignedUrl(speakerImageKey, 60);

--- a/src/main/java/goorm/back/zo6/conference/domain/Session.java
+++ b/src/main/java/goorm/back/zo6/conference/domain/Session.java
@@ -58,7 +58,7 @@ public class Session {
     private String speakerImageKey;
 
     public Session(Conference conference, String name, Integer capacity, String location, LocalDateTime startTime, LocalDateTime endTime, String summary, String speakerName, String speakerOrganization) {
-        if (conference == null) {
+        if (conference == null || conference.getId() == null) {
             throw new CustomException(ErrorCode.CONFERENCE_NOT_FOUND);
         }
         if (startTime == null || endTime == null || endTime.isBefore(startTime) || endTime.isEqual(startTime)) {
@@ -86,7 +86,7 @@ public class Session {
     public boolean isReservable() { return capacity > 0; }
 
     public void setConference(Conference conference) {
-        if (conference == null) {
+        if (conference == null || conference.getId() == null) {
             throw new CustomException(ErrorCode.CONFERENCE_NOT_FOUND);
         }
         this.conference = conference;

--- a/src/test/java/goorm/back/zo6/reservation/application/ReservationQueryServiceImplTest.java
+++ b/src/test/java/goorm/back/zo6/reservation/application/ReservationQueryServiceImplTest.java
@@ -37,7 +37,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈:
- close #163 

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 개선이 필요한 사항을 간략히 설명해주세요.
- 세션, 컨퍼런스 등록 할때 이미지 값이 "" (빈) 값 이면 s3 예외가 터짐

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 달성하고자 하는 목표를 설명해주세요.
- s3에서 "" (빈) 값 일 때 null 처리하는 로직 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] s3 처리 로직 수정

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)
