### PR TITLE
유저 회원가입 시 임시 예매와 링크 하는 api 추가

### DIFF
--- a/src/main/java/goorm/back/zo6/auth/config/SecurityConfig.java
+++ b/src/main/java/goorm/back/zo6/auth/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**","/actuator/**").permitAll() // Swagger 관련 경로 허용
-                .requestMatchers("/api/v1/users/signup","/api/v1/auth/login","/api/v1/users/check-email").permitAll()
+                .requestMatchers("/api/v1/users/signup","/api/v1/auth/login","/api/v1/users/signup-link","/api/v1/users/check-email").permitAll()
                 .requestMatchers("/api/v1/users/code","/api/v1/users/verify").permitAll()
                 .requestMatchers("/api/v1/rekognition/authentication").permitAll()
                 .requestMatchers("/api/v1/reservation/temp").permitAll()

--- a/src/main/java/goorm/back/zo6/common/exception/ErrorCode.java
+++ b/src/main/java/goorm/back/zo6/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     // User Error
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     USER_ALREADY_EXISTS(HttpStatus.NOT_FOUND, "이미 존재하는 유저입니다."),
+    PHONE_NOT_VERIFIED(HttpStatus.NOT_ACCEPTABLE, "번호 인증 실패"),
 
     // Login Error
     USER_NOT_MATCH_LOGIN_INFO(HttpStatus.BAD_REQUEST, "로그인 정보에 해당하는 유저가 존재하지 않습니다."),

--- a/src/main/java/goorm/back/zo6/user/application/PhoneValidService.java
+++ b/src/main/java/goorm/back/zo6/user/application/PhoneValidService.java
@@ -57,7 +57,22 @@ public class PhoneValidService {
         if(generatedCode ==null){
             throw new CustomException(ErrorCode.EXPIRED_PHONE);
         }
-        return generatedCode.equals(code);
+
+        boolean isValid = generatedCode.equals(code);
+
+        if (isValid) {
+            redisTemplate.opsForValue().set(phone + ":verified", "true", Duration.ofMinutes(3));
+        }
+
+        return isValid;
+    }
+
+    public boolean isPhoneAlreadyVerified(String phone){
+        return Boolean.TRUE.equals(redisTemplate.hasKey(phone + ":verified"));
+    }
+
+    public void removeVerifiedPhone(String phone){
+        redisTemplate.delete(phone + ":verified");
     }
 
     private int generateRandomNumber(){

--- a/src/main/java/goorm/back/zo6/user/application/UserValidator.java
+++ b/src/main/java/goorm/back/zo6/user/application/UserValidator.java
@@ -1,0 +1,22 @@
+package goorm.back.zo6.user.application;
+
+import goorm.back.zo6.common.exception.CustomException;
+import goorm.back.zo6.common.exception.ErrorCode;
+import goorm.back.zo6.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidator {
+
+    private final PhoneValidService phoneValidService;
+
+    private final UserRepository userRepository;
+
+    public void validatePhone(String phone) {
+        if (!phoneValidService.isPhoneAlreadyVerified(phone)) {
+            throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
+        }
+    }
+}

--- a/src/main/java/goorm/back/zo6/user/presentation/UserController.java
+++ b/src/main/java/goorm/back/zo6/user/presentation/UserController.java
@@ -43,9 +43,16 @@ public class UserController {
     }
 
     @PostMapping("/signup")
-    @Operation(summary = "회원가입", description = "회원가입 정보를 통해 유저를 생성 및 등록 합니다.")
-    public ResponseEntity<ResponseDto<SignUpResponse>> signUp(@Validated @RequestBody SignUpRequest request) {
+    @Operation(summary = "회원가입(테스트용)", description = "회원가입 정보를 통해 유저를 생성 및 등록 합니다.")
+    public ResponseEntity<ResponseDto<SignUpResponse>> signUp(
+            @Validated @RequestBody SignUpRequest request) {
         return ResponseEntity.ok().body(ResponseDto.of(userService.signUp(request)));
+    }
+
+    @PostMapping("/signup-link")
+    @Operation(summary = "회원가입-임시 예매 링크", description = "회원가입 시 임시 예매와 링크 됩니다.")
+    public ResponseEntity<ResponseDto<SignUpResponse>> signUpLink(@Validated @RequestBody SignUpRequest request) {
+        return ResponseEntity.ok().body(ResponseDto.of(userService.signUpWithPhone(request)));
     }
 
     @PutMapping("/phone")


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈:
- closed #188

---

## 🧐 현재 상황

<!-- 현재 발생한 문제, 개선이 필요한 사항을 간략히 설명해주세요. -->

- 개선이 필요한 사항을 간략히 설명해주세요.
- 현재 회원가입 시 유저와 임시 예매를 연동 하는 api 가 따로 존재

---

## 🎯 목표

<!-- 이슈를 통해 달성하고자 하는 목표를 설명해주세요. -->

- 달성하고자 하는 목표를 설명해주세요.
- 회원가입 시 자동으로 유저와 임시 예매가 전화번호를 통해 연동 하게 회원가입 api 수정

---

## 🛠 작업 내용

- 작업 할 내용을 입력해주세요.

- [x] UserController에 signup-link 추가
- [x] UserServiec에 회원가입 시 임시 예매와 링크 되는 로직 추가
- [x] error 코드 추가
- [x] 시큐리티 singup-link 추가

---

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

- 추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)
